### PR TITLE
Fix RadioButton, OptionGroup, Blockquote

### DIFF
--- a/src/atoms/text/Blockquote.tsx
+++ b/src/atoms/text/Blockquote.tsx
@@ -1,27 +1,33 @@
 import React from 'react';
 
 export interface BlockquoteProps {
-    /**
-     * Set strong style for all content
-     */
-    isStrong?: boolean,
-    /**
-     * Blockquote content
-     */
-    content: string
+  /**
+   * Set strong style for all content
+   */
+  isStrong?: boolean;
+  /**
+   * Blockquote content
+   */
+  content?: string;
+  children?: React.ReactNode;
 }
 
-export const Blockquote = ({isStrong = false, content = "Blockquote content"}: BlockquoteProps): JSX.Element => {
+export const Blockquote = ({
+  isStrong = false,
+  content = 'Blockquote content',
+  children
+}: BlockquoteProps): JSX.Element => {
+  const defaultClasses =
+    'pullquote u-theme--border-color--darker--left u-theme--color--darker u-padding--right';
 
-    const defaultClasses = "pullquote u-theme--border-color--darker--left u-theme--color--darker u-padding--right";
-
-    return (
-        <div className={"text"}>
-            <blockquote className={defaultClasses + " " + (isStrong ? "o-pullquote--strong" : "")}>
-                <p>
-                    {content}
-                </p>
-            </blockquote>
-        </div>
-    )
-}
+  return (
+    <div className={'text'}>
+      <blockquote
+        className={
+          `${defaultClasses} ${isStrong ? 'o-pullquote--strong' : 'u-border--left'}`}
+      >
+        {children || <p>{content}</p>}
+      </blockquote>
+    </div>
+  );
+};

--- a/src/molecules/forms/elements/OptionGroup.tsx
+++ b/src/molecules/forms/elements/OptionGroup.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 import renderItems from "../../../helpers/renderItems";
 import {fontSizesMap, fontTypesMap, getFontClass} from "../../../global/fonts";
-import {Checkbox} from "./Checkbox";
-import RadioButton from "./RadioButton";
+import {Checkbox, CheckboxProps} from "./Checkbox";
+import { RadioButton, RadioButtonProps } from "./RadioButton";
 
 const components = {
     checkbox: Checkbox,
@@ -16,9 +16,10 @@ export interface OptionGroupProps {
     title: string,
     titleFontSize?: keyof typeof fontSizesMap,
     titleFontType?: keyof typeof fontTypesMap,
-    options?: [],
+     options?: OptionItem[],
     type?: "checkbox" | "radio"
 }
+export type OptionItem = CheckboxProps | RadioButtonProps;
 
 export const OptionGroup = ({
                                 children,

--- a/src/molecules/forms/elements/RadioButton.tsx
+++ b/src/molecules/forms/elements/RadioButton.tsx
@@ -17,18 +17,17 @@ export interface RadioButtonProps {
 }
 
 export const RadioButton = ({
-                                checked,
-                                error,
-                                id,
-                                label,
-                                labelOptional,
-                                labelClass,
-                                labelSpacing,
-                                name,
-                                value,
-                                ...props
-                            }: RadioButtonProps): JSX.Element => {
-
+    checked,
+    error,
+    id,
+    label,
+    labelOptional,
+    labelClass = "",
+    labelSpacing = "",
+    name,
+    value,
+    ...props
+}: RadioButtonProps): JSX.Element => {
     return (
         <FormLabel
             className={labelClass}
@@ -51,11 +50,3 @@ export const RadioButton = ({
         </FormLabel>
     )
 }
-
-RadioButton.propTypes = {}
-RadioButton.defaultProps = {
-    labelClass: null,
-    labelSpacing: null,
-}
-
-export default RadioButton


### PR DESCRIPTION
- Blockquote - added children
- RadiioButton.tsx - Fixed JS eror: hook.js:608 Warning: RadioButton: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
-OptionGroup,tsx - added type for options property