### PR TITLE
Bug: onChange of BaseInput brakes editing the field

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
+  "editor.formatOnPaste": false, // required
+  "editor.formatOnType": false, // required
+  "editor.formatOnSave": true, // optional
+  "editor.formatOnSaveMode": "file", // required to format on save
+  "files.autoSave": "onFocusChange",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "files.exclude": {
+    "**/js/script.min.js": true
+  },
+  "files.watcherExclude": {
+    "**/js/script.min.js": true
+  },
+  "[sass]": {
+    "editor.defaultFormatter": "MikeBovenlander.formate"
+  },
+  "[ruby]": {
+    "editor.defaultFormatter": "svipas.prettier-plus"
+  }, // optional but recommended
+  // "[scss]": {
+  //   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  // }
+ 
+}

--- a/src/molecules/forms/elements/BaseInput.tsx
+++ b/src/molecules/forms/elements/BaseInput.tsx
@@ -1,12 +1,10 @@
-import React, {MouseEventHandler, useState} from 'react';
+import React, {useMemo} from 'react';
 
 import useClasses from '../../../helpers/useClasses';
-import useInputFocus from '../../../helpers/useInputFocus';
 
 export interface BaseInputProps {
   checked?: boolean;
   error?: string;
-  hasFocus?: boolean;
   id?: string;
   name?: string;
   placeholder?: string;
@@ -23,7 +21,10 @@ export interface BaseInputProps {
   value?: string;
   required?: boolean;
   accept?: string;
-  onClick?: (event: MouseEventHandler<HTMLAnchorElement>) => void;
+  rows?: number;
+  onClick?: (
+    e: React.MouseEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
   onChange?: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
@@ -36,13 +37,13 @@ export const BaseInput = ({
   checked,
   error,
   type = 'text',
-  value,
-  hasFocus = false,
+  value = '',
   name,
   id,
   placeholder,
   required = false,
   accept,
+  rows,
   onChange,
   onClick,
   onBlur
@@ -51,10 +52,6 @@ export const BaseInput = ({
     'has-error': !!error
   });
 
-  const [fileName, setFileName] = useState<string>('');
-
-  const inputFocusRef = useInputFocus(hasFocus);
-
   const isTextArea = type === 'textarea';
   const isFile = type === 'file';
 
@@ -62,40 +59,45 @@ export const BaseInput = ({
     display: 'none'
   };
 
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    if (e.target instanceof HTMLInputElement && e.target.type === 'file') {
-      setFileName(e.target.files?.[0]?.name || '');
+  const fileName = useMemo(() => {
+    if (isFile && typeof value === 'string' && value) {
+      // Extract file name from the value (full path or file name)
+      const parts = value.split(/(\\|\/)/g);
+      return parts[parts.length - 1];
     }
+    return '';
+  }, [isFile, value]);
 
-    if (onChange) onChange(e);
-    return true;
+  const elementProps: React.InputHTMLAttributes<HTMLInputElement> &
+    React.TextareaHTMLAttributes<HTMLTextAreaElement> = {
+    className: inputClass,
+    type: isTextArea ? undefined : type,
+    rows: isTextArea ? rows : undefined,
+    name: name,
+    id: id || name,
+    placeholder: placeholder,
+    required: required,
+    accept: isFile ? accept : undefined,
+    onChange: onChange,
+    autoComplete: 'on',
+    onBlur: onBlur,
+    style: isFile ? fileStyles : undefined,
+    value: value
   };
+  // Only assign onClick if it's a valid input event handler
+  if (!isTextArea && typeof onClick === 'function') {
+    (elementProps as React.InputHTMLAttributes<HTMLInputElement>).onClick =
+      onClick as unknown as React.MouseEventHandler<HTMLInputElement>;
+  }
+  if ((type === 'checkbox' || type === 'radio') && checked !== undefined) {
+    (
+      elementProps as React.InputHTMLAttributes<HTMLInputElement>
+    ).defaultChecked = checked;
+  }
 
-  const element = React.createElement(
-    isTextArea ? 'textarea' : 'input',
-    {
-      className: inputClass,
-      defaultChecked: checked,
-      defaultValue: value,
-      ref: inputFocusRef,
-      type,
-      name: name,
-      id: id || name,
-      placeholder: placeholder,
-      required: required,
-      accept: isFile ? accept : undefined,
-      onChange: handleChange,
-      autocomplete: 'on',
-      onClick: isTextArea ? null : onClick,
-      onBlur: onBlur,
-      style: {
-        ...(isFile ? fileStyles : {})
-      }
-    },
-    isTextArea ? value : null
-  );
+  const element = isTextArea
+    ? React.createElement('textarea', elementProps)
+    : React.createElement('input', elementProps);
 
   return (
     <>

--- a/src/molecules/forms/elements/RadioButton.tsx
+++ b/src/molecules/forms/elements/RadioButton.tsx
@@ -1,4 +1,4 @@
-import React, {MouseEventHandler} from "react";
+import React from "react";
 import {FormLabel} from "./FormLabel";
 import {BaseInput} from "./BaseInput";
 
@@ -13,7 +13,7 @@ export interface RadioButtonProps {
     name: string,
     placeholder?: string,
     value?: string,
-    onClick?: (event: MouseEventHandler<HTMLAnchorElement>) => void;
+    onClick?: (e: React.MouseEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }
 
 export const RadioButton = ({

--- a/src/molecules/forms/elements/TextField.tsx
+++ b/src/molecules/forms/elements/TextField.tsx
@@ -1,4 +1,4 @@
-import React, {useImperativeHandle, forwardRef, MouseEventHandler} from 'react';
+import React from 'react';
 
 import {FormLabel} from './FormLabel';
 import {BaseInput} from './BaseInput';
@@ -30,93 +30,44 @@ export interface TextFieldProps {
   onChange?: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
-  onClick?: (event: MouseEventHandler<HTMLAnchorElement>) => void;
+  onClick?: (
+    e: React.MouseEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
+  onBlur?: (
+    e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
+  touched?: boolean;
 }
 
-export interface TextFieldRef {
-  isValid: () => boolean;
-}
+export const TextField = ({
+  label,
+  labelOptional,
+  labelClass,
+  labelTagClass,
+  faIcon,
+  labelSpacing,
+  touched = false,
+  ...props
+}: TextFieldProps): JSX.Element => {
+  const isValid =
+    !props.required || (!!props.value && props.value.trim() !== '');
+  const showRequiredError = !isValid && touched;
 
-export const TextField = forwardRef<TextFieldRef, TextFieldProps>(
-  (
-    {
-      label,
-      labelOptional,
-      labelClass,
-      labelTagClass,
-      faIcon,
-      labelSpacing,
-      type = 'text',
-      rows,
-      onChange,
-      onClick,
-      ...props
-    }: TextFieldProps,
-    ref
-  ): JSX.Element => {
-    const [value, setValue] = React.useState(props.value || '');
-    const [touched, setTouched] = React.useState(false);
-
-    const isValid = !props.required || (!!value && value.trim() !== '');
-
-    const showError = touched && !isValid;
-
-    React.useEffect(() => {
-      setValue(props.value || '');
-    }, [props.value]);
-
-    useImperativeHandle(ref, () => ({
-      isValid: () => isValid
-    }));
-
-    const handleChange = (
-      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-    ) => {
-      setValue(e.target.value);
-      if (onChange) onChange(e);
-      return true;
-    };
-
-    const handleBlur = () => {
-      setTouched(true);
-    };
-
-    return (
-      <FormLabel
-        className={labelClass}
-        labelClass={`${labelTagClass} ${
-          type === 'file' ? 'u-space--quarter' : ''
-        }`}
-        error={showError ? 'Полето е задължително' : props.error}
-        htmlFor={props.name}
-        text={label}
-        textOptional={labelOptional}
-        faIcon={faIcon}
-        required={props.required}
-        // spacing={labelSpacing}
-      >
-        {type === 'textarea' ? (
-          <textarea
-            required={props.required}
-            id={props.id || props.name}
-            name={props.name}
-            rows={rows}
-            placeholder={props.placeholder}
-            // value={value}
-            onChange={handleChange}
-            onBlur={handleBlur}
-          />
-        ) : (
-          <BaseInput
-            {...props}
-            type={type}
-            value={value}
-            onChange={handleChange}
-            onClick={onClick}
-            onBlur={handleBlur}
-          />
-        )}
-      </FormLabel>
-    );
-  }
-);
+  return (
+    <FormLabel
+      className={labelClass}
+      labelClass={`${labelTagClass} ${
+        props.type === 'file' ? 'u-space--quarter' : ''
+      }`}
+      error={showRequiredError ? 'Полето е задължително' : props.error ?? ''}
+      htmlFor={props.name}
+      text={label}
+      textOptional={labelOptional}
+      faIcon={faIcon}
+      required={props.required}
+      // spacing={labelSpacing}
+    >
+      <BaseInput {...props} />
+    </FormLabel>
+  );
+};


### PR DESCRIPTION
- BaseInput and TextField do not use internal state for value

- BaseInput.tsx
  - added rows property
  - The textarea now receives its value only as a prop (not as a child), and defaultChecked is only set for checkboxes/radios
  - updated onClick event type
  - removed the ref and the unused focus logic from BaseInput. Now, the component is a pure controlled input/textarea with no interference from refs or custom focus hooks
  - shouldn't use useState; use useMemo to calculate fileName

- TextField.txs
  - updated onClick event type
  - Remove its internal useState for value and touched. Use only the value and onChange props from the parent.
  - onBlur, touched - added properties
  - always use BaseInput

Added .vscode/settings.json - for formatting